### PR TITLE
update templating to support alb redirect

### DIFF
--- a/charts/neutrino/Chart.yaml
+++ b/charts/neutrino/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/neutrino/templates/ingress.yaml
+++ b/charts/neutrino/templates/ingress.yaml
@@ -47,11 +47,15 @@ spec:
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if and (semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion) (.backend) }}
               service:
-                name: {{ $fullName }}
+                name: {{ .backend.service.name }}
                 port:
+                  {{- if .backend.service.port.name }}
+                  name: {{ .backend.service.port.name }}
+                  {{- else }}
                   number: {{ $svcPort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}


### PR DESCRIPTION
take two. had to edit the template so that it propagated through the redirect. 
running a `helm template` locally results in the following, which looks better.
```
# Source: neutrino/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: neutrino
  labels:
    helm.sh/chart: neutrino-0.1.2
    app.kubernetes.io/name: neutrino
    app.kubernetes.io/instance: neutrino
    app.kubernetes.io/version: "0.9.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig":
      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
    alb.ingress.kubernetes.io/healthcheck-path: /staging/api/health_check/liveness
    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/success-codes: "200"
    alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
    kubernetes.io/ingress.class: alb
spec:
  rules:
    - host: "execution.neutrino.yoko.sandbox.transposit.com"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: ssl-redirect
                port:
                  name: use-annotation
          - path: /
            pathType: Prefix
            backend:
              serviceName: neutrino
              servicePort: 80
```